### PR TITLE
Updating deps and tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,8 +19,8 @@ defmodule FlatbufferPort.Mixfile do
 
   defp deps do
     [
-      {:flatbuffers, [github: "google/flatbuffers", tag: "v1.7.1", compile: false, app: false]},
-      {:poison, "~> 3.1"}
+      {:flatbuffers, [github: "google/flatbuffers", tag: "v1.11.0", compile: false, app: false]},
+      {:jason, "~> 1.1.2", [only: :test]}
     ]
   end
 end
@@ -28,7 +28,7 @@ end
 defmodule Mix.Tasks.Compile.Port do
   def run(_) do
     if Mix.shell.cmd("make priv/fb_port") != 0 do
-      raise Mix.Error, message: "Could not run `make priv/fb_port`. Do you have make and gcc installed?"
+      raise Mix.Error, message: "Could not run `make priv/fb_port`. Do you have make and clang installed?"
     end
   end
 end

--- a/test/flatbuffer_port_test.exs
+++ b/test/flatbuffer_port_test.exs
@@ -53,7 +53,7 @@ defmodule FlatbufferPortTest do
     FlatbufferPort.load_schema(port, schema)
     assert {:response, "ok"} == collect_response()
     FlatbufferPort.json_to_fb(port, json)
-    assert {:response, "error: 1:0: error: unknown field: questsx"} == collect_response()
+    assert {:response, "error: 1: 12: error: unknown field: questsx"} == collect_response()
   end
 
   test "convert flatbuffer to json" do
@@ -65,7 +65,7 @@ defmodule FlatbufferPortTest do
     assert {:response, "ok"} == collect_response()
     FlatbufferPort.fb_to_json(port, flatbuffer)
     {:response, converted_json} = collect_response()
-    assert Poison.decode!(json) == Poison.decode!(converted_json)
+    assert Jason.decode!(json) == Jason.decode!(converted_json)
   end
 
   test "return error when flatbuffer has wrong identitifier" do

--- a/test/flatbuffer_test.exs
+++ b/test/flatbuffer_test.exs
@@ -39,7 +39,7 @@ defmodule FlatbufferTest do
     {:response, fb} = collect_response()
     assert true = FlatbufferPort.fb_to_json(port, fb)
     {:response, json_looped} = collect_response()
-    assert Poison.decode(json) == Poison.decode(json_looped)
+    assert Jason.decode(json) == Jason.decode(json_looped)
   end
 
   test "order of values in the json should not matter", %{schema: schema} do
@@ -59,7 +59,7 @@ defmodule FlatbufferTest do
     {:response, fb} = collect_response()
     FlatbufferPort.fb_to_json(port, fb)
     {:response, json_looped} = collect_response()
-    assert Poison.decode(json) == Poison.decode(json_looped)
+    assert Jason.decode(json) == Jason.decode(json_looped)
   end
 
   def collect_response() do


### PR DESCRIPTION
This PR updates the flatbuffer version and tests.  It also adjusts Poison -> [Jason](https://github.com/michalmuskala/jason), a faster lib, and makes it test only.  Also updating the error message, because I assume osx was used for this and `gcc` is symlinked to `clang`.

Caveat, one of the tests fails because the .bin file needs to be updated.  Not exactly sure on how to do that.